### PR TITLE
Inherit rtl direction for new blocks

### DIFF
--- a/app/src/block/util.ts
+++ b/app/src/block/util.ts
@@ -143,7 +143,7 @@ export const insertEmptyBlock = (protyle: IProtyle, position: InsertPosition, id
         return;
     }
     protyle.observerLoad?.disconnect();
-    let newElement = genEmptyElement(false, true);
+    let newElement = genEmptyElement(false, true, undefined, blockElement);
     let orderIndex = 1;
     if (blockElement.getAttribute("data-type") === "NodeListItem") {
         newElement = genListItemElement(blockElement, 0, true) as HTMLDivElement;
@@ -205,12 +205,21 @@ export const genEmptyBlock = (zwsp = true, wbr = true, string?: string) => {
     return `<div data-node-id="${Lute.NewNodeID()}" data-type="NodeParagraph" class="p"><div contenteditable="true" spellcheck="${window.siyuan.config.editor.spellcheck}">${html}</div><div contenteditable="false" class="protyle-attr">${Constants.ZWSP}</div></div>`;
 };
 
-export const genEmptyElement = (zwsp = true, wbr = true, id?: string) => {
+export const genEmptyElement = (zwsp = true, wbr = true, id?: string, previousElement?: Element) => {
     const element = document.createElement("div");
     element.setAttribute("data-node-id", id || Lute.NewNodeID());
     element.setAttribute("data-type", "NodeParagraph");
     element.classList.add("p");
     element.innerHTML = `<div contenteditable="true" spellcheck="${window.siyuan.config.editor.spellcheck}">${zwsp ? Constants.ZWSP : ""}${wbr ? "<wbr>" : ""}</div><div class="protyle-attr" contenteditable="false">${Constants.ZWSP}</div>`;
+    
+    // Inherit text direction from previous element if configuration is enabled (default: true)
+    if ((window.siyuan.config.editor.inheritTextDirection ?? true) && previousElement) {
+        const direction = getComputedStyle(previousElement).direction;
+        if (direction === "rtl") {
+            element.style.direction = "rtl";
+        }
+    }
+    
     return element;
 };
 

--- a/app/src/config/editor.ts
+++ b/app/src/config/editor.ts
@@ -38,6 +38,14 @@ export const editor = {
 </label>
 <label class="fn__flex b3-label">
     <div class="fn__flex-1">
+        ${window.siyuan.languages.inheritTextDirection || "Inherit text direction from previous block"}
+        <div class="b3-label__text">${window.siyuan.languages.inheritTextDirectionTip || "When creating a new block, inherit the text direction from the previous block"}</div>
+    </div>
+    <span class="fn__space"></span>
+    <input class="b3-switch fn__flex-center" id="inheritTextDirection" type="checkbox"${(window.siyuan.config.editor.inheritTextDirection ?? true) ? " checked" : ""}/>
+</label>
+<label class="fn__flex b3-label">
+    <div class="fn__flex-1">
         ${window.siyuan.languages.editReadonly} 
         <code class="fn__code${window.siyuan.config.keymap.general.editReadonly.custom ? "" : " fn__none"}">${updateHotkeyTip(window.siyuan.config.keymap.general.editReadonly.custom)}</code>
         <div class="b3-label__text">${window.siyuan.languages.editReadonlyTip}</div>
@@ -423,6 +431,7 @@ export const editor = {
                 allowHTMLBLockScript: (editor.element.querySelector("#allowHTMLBLockScript") as HTMLInputElement).checked,
                 justify: (editor.element.querySelector("#justify") as HTMLInputElement).checked,
                 rtl: (editor.element.querySelector("#rtl") as HTMLInputElement).checked,
+                inheritTextDirection: (editor.element.querySelector("#inheritTextDirection") as HTMLInputElement).checked,
                 readOnly: (editor.element.querySelector("#readOnly") as HTMLInputElement).checked,
                 displayBookmarkIcon: (editor.element.querySelector("#displayBookmarkIcon") as HTMLInputElement).checked,
                 displayNetImgMark: (editor.element.querySelector("#displayNetImgMark") as HTMLInputElement).checked,

--- a/app/src/mobile/settings/editor.ts
+++ b/app/src/mobile/settings/editor.ts
@@ -26,9 +26,10 @@ const setEditor = (modelMainElement: Element) => {
     };
     window.siyuan.config.editor.allowHTMLBLockScript = (modelMainElement.querySelector("#allowHTMLBLockScript") as HTMLInputElement).checked;
     window.siyuan.config.editor.dynamicLoadBlocks = dynamicLoadBlocks;
-    window.siyuan.config.editor.justify = (modelMainElement.querySelector("#justify") as HTMLInputElement).checked;
-    window.siyuan.config.editor.rtl = (modelMainElement.querySelector("#rtl") as HTMLInputElement).checked;
-    window.siyuan.config.editor.readOnly = (modelMainElement.querySelector("#readOnly") as HTMLInputElement).checked;
+            window.siyuan.config.editor.justify = (modelMainElement.querySelector("#justify") as HTMLInputElement).checked;
+        window.siyuan.config.editor.rtl = (modelMainElement.querySelector("#rtl") as HTMLInputElement).checked;
+        window.siyuan.config.editor.inheritTextDirection = (modelMainElement.querySelector("#inheritTextDirection") as HTMLInputElement).checked;
+        window.siyuan.config.editor.readOnly = (modelMainElement.querySelector("#readOnly") as HTMLInputElement).checked;
     window.siyuan.config.editor.displayBookmarkIcon = (modelMainElement.querySelector("#displayBookmarkIcon") as HTMLInputElement).checked;
     window.siyuan.config.editor.displayNetImgMark = (modelMainElement.querySelector("#displayNetImgMark") as HTMLInputElement).checked;
     window.siyuan.config.editor.codeSyntaxHighlightLineNum = (modelMainElement.querySelector("#codeSyntaxHighlightLineNum") as HTMLInputElement).checked;
@@ -82,6 +83,14 @@ export const initEditor = () => {
     </div>
     <span class="fn__space"></span>
     <input class="b3-switch fn__flex-center" id="rtl" type="checkbox"${window.siyuan.config.editor.rtl ? " checked" : ""}/>
+</label>
+<label class="fn__flex b3-label">
+    <div class="fn__flex-1">
+        ${window.siyuan.languages.inheritTextDirection || "Inherit text direction from previous block"}
+        <div class="b3-label__text">${window.siyuan.languages.inheritTextDirectionTip || "When creating a new block, inherit the text direction from the previous block"}</div>
+    </div>
+    <span class="fn__space"></span>
+    <input class="b3-switch fn__flex-center" id="inheritTextDirection" type="checkbox"${(window.siyuan.config.editor.inheritTextDirection ?? true) ? " checked" : ""}/>
 </label>
 <label class="fn__flex b3-label">
     <div class="fn__flex-1">

--- a/app/src/protyle/header/Title.ts
+++ b/app/src/protyle/header/Title.ts
@@ -146,7 +146,8 @@ export class Title {
                     focusBlock(protyle.wysiwyg.element.firstElementChild, protyle.wysiwyg.element);
                 } else {
                     const newId = Lute.NewNodeID();
-                    const newElement = genEmptyElement(false, true, newId);
+                    const previousElement = protyle.wysiwyg.element.firstElementChild;
+                    const newElement = genEmptyElement(false, true, newId, previousElement);
                     protyle.wysiwyg.element.insertAdjacentElement("afterbegin", newElement);
                     focusByWbr(newElement, protyle.toolbar.range || getEditorRange(newElement));
                     transaction(protyle, [{

--- a/app/src/protyle/ui/initUI.ts
+++ b/app/src/protyle/ui/initUI.ts
@@ -146,7 +146,8 @@ export const initUI = (protyle: IProtyle) => {
                     (protyle.wysiwyg.element.lastElementChild.getAttribute("data-type") !== "NodeParagraph" && protyle.wysiwyg.element.getAttribute("data-doc-type") !== "NodeListItem") ||
                     (protyle.wysiwyg.element.lastElementChild.getAttribute("data-type") === "NodeParagraph" && getContenteditableElement(lastEditElement).innerHTML !== ""))
                 ) {
-                    const emptyElement = genEmptyElement(false, false);
+                    const previousElement = protyle.wysiwyg.element.lastElementChild;
+                    const emptyElement = genEmptyElement(false, false, undefined, previousElement);
                     protyle.wysiwyg.element.insertAdjacentElement("beforeend", emptyElement);
                     transaction(protyle, [{
                         action: "insert",

--- a/app/src/protyle/wysiwyg/enter.ts
+++ b/app/src/protyle/wysiwyg/enter.ts
@@ -176,7 +176,7 @@ export const enter = (blockElement: HTMLElement, range: Range, protyle: IProtyle
 
     // 段首换行
     if (editableElement.textContent !== "" && range.toString() === "" && position.start === 0) {
-        const newElement = genEmptyElement(false, true);
+        const newElement = genEmptyElement(false, true, undefined, blockElement);
         const newId = newElement.getAttribute("data-node-id");
         transaction(protyle, [{
             action: "insert",
@@ -216,7 +216,7 @@ export const enter = (blockElement: HTMLElement, range: Range, protyle: IProtyle
     }
     const id = blockElement.getAttribute("data-node-id");
     const newElement = document.createElement("div");
-    newElement.appendChild(genEmptyElement(false, false));
+    newElement.appendChild(genEmptyElement(false, false, undefined, blockElement));
     const newEditableElement = newElement.querySelector('[contenteditable="true"]');
     newEditableElement.appendChild(range.extractContents());
     const selectWbrElement = newEditableElement.querySelector("wbr");

--- a/app/src/protyle/wysiwyg/list.ts
+++ b/app/src/protyle/wysiwyg/list.ts
@@ -33,13 +33,23 @@ export const updateListOrder = (listElement: Element, sIndex?: number) => {
 export const genListItemElement = (listItemElement: Element, offset = 0, wbr = false) => {
     const element = document.createElement("template");
     const type = listItemElement.getAttribute("data-subtype");
+    let directionStyle = "";
+    
+    // Inherit text direction from previous element if configuration is enabled (default: true)
+    if ((window.siyuan.config.editor.inheritTextDirection ?? true) && listItemElement) {
+        const direction = getComputedStyle(listItemElement).direction;
+        if (direction === "rtl") {
+            directionStyle = ' style="direction: rtl;"';
+        }
+    }
+    
     if (type === "o") {
         const index = parseInt(listItemElement.getAttribute("data-marker")) + offset;
-        element.innerHTML = `<div data-marker="${index + 1}." data-subtype="${type}" data-node-id="${Lute.NewNodeID()}" data-type="NodeListItem" class="li"><div contenteditable="false" class="protyle-action protyle-action--order" draggable="true">${index + 1}.</div>${genEmptyBlock(false, wbr)}<div class="protyle-attr" contenteditable="false"></div></div>`;
+        element.innerHTML = `<div data-marker="${index + 1}." data-subtype="${type}" data-node-id="${Lute.NewNodeID()}" data-type="NodeListItem" class="li"${directionStyle}><div contenteditable="false" class="protyle-action protyle-action--order" draggable="true">${index + 1}.</div>${genEmptyBlock(false, wbr)}<div class="protyle-attr" contenteditable="false"></div></div>`;
     } else if (type === "t") {
-        element.innerHTML = `<div data-marker="*" data-subtype="${type}" data-node-id="${Lute.NewNodeID()}" data-type="NodeListItem" class="li"><div class="protyle-action protyle-action--task" draggable="true"><svg><use xlink:href="#iconUncheck"></use></svg></div>${genEmptyBlock(false, wbr)}<div class="protyle-attr" contenteditable="false"></div></div>`;
+        element.innerHTML = `<div data-marker="*" data-subtype="${type}" data-node-id="${Lute.NewNodeID()}" data-type="NodeListItem" class="li"${directionStyle}><div class="protyle-action protyle-action--task" draggable="true"><svg><use xlink:href="#iconUncheck"></use></svg></div>${genEmptyBlock(false, wbr)}<div class="protyle-attr" contenteditable="false"></div></div>`;
     } else {
-        element.innerHTML = `<div data-marker="*" data-subtype="${type}" data-node-id="${Lute.NewNodeID()}" data-type="NodeListItem" class="li"><div class="protyle-action" draggable="true"><svg><use xlink:href="#iconDot"></use></svg></div>${genEmptyBlock(false, wbr)}<div class="protyle-attr" contenteditable="false"></div></div>`;
+        element.innerHTML = `<div data-marker="*" data-subtype="${type}" data-node-id="${Lute.NewNodeID()}" data-type="NodeListItem" class="li"${directionStyle}><div class="protyle-action" draggable="true"><svg><use xlink:href="#iconDot"></use></svg></div>${genEmptyBlock(false, wbr)}<div class="protyle-attr" contenteditable="false"></div></div>`;
     }
     return element.content.firstElementChild as HTMLElement;
 };

--- a/app/src/types/config.d.ts
+++ b/app/src/types/config.d.ts
@@ -468,6 +468,10 @@ declare namespace Config {
          */
         rtl: boolean;
         /**
+         * Whether to inherit text direction from previous block when creating new blocks
+         */
+        inheritTextDirection: boolean;
+        /**
          * Whether to enable spell checking
          */
         spellcheck: boolean;


### PR DESCRIPTION
## Feature or bug? 特性或者缺陷？
Feature.

## Multilingual or copywriting? 多语言或者文案？
Adds a new UI string for the setting.

## Dev branch!

### What's changed?
This PR introduces a new feature that automatically inherits the text direction (RTL/LTR) from the previous block when a new block is created.

### Why?
To improve the user experience for those working with Right-to-Left (RTL) languages. Users will no longer need to manually set the direction for each new block when continuing to type in RTL.

### How?
- A new configuration option `inheritTextDirection` (default: `true`) is added to editor settings, with corresponding UI toggles for desktop and mobile.
- Block creation functions are updated to check the previous block's direction and apply `style="direction: rtl;"` to the new block if the setting is enabled and the previous block is RTL.

---
<a href="https://cursor.com/background-agent?bcId=bc-80170d6b-cb57-49de-b09c-1026f8ff5991">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80170d6b-cb57-49de-b09c-1026f8ff5991">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>