### PR TITLE
Remove cloud and account UI elements

### DIFF
--- a/CLOUD_UI_REMOVAL.md
+++ b/CLOUD_UI_REMOVAL.md
@@ -1,0 +1,64 @@
+# SiYuan Cloud UI Removal
+
+This document describes the cloud UI removal feature that hides all account, subscription, and cloud sync related UI elements in SiYuan.
+
+## Implementation
+
+The feature is controlled by the `hideCloudUI` boolean flag in the system configuration (`window.siyuan.config.system.hideCloudUI`).
+
+### What gets hidden when `hideCloudUI` is enabled:
+
+1. **Settings Page (Desktop & Mobile)**
+   - Account section is hidden
+   - Cloud/Repos section is hidden
+
+2. **Mobile Menu**
+   - Account menu item is hidden
+   - Cloud sync menu items are hidden
+
+3. **Desktop Topbar**
+   - Sync button is hidden
+   - VIP/subscription toolbar elements are hidden
+
+4. **Subscription System**
+   - `needSubscribe()` always returns `false` (bypasses subscription checks)
+   - `isPaidUser()` always returns `true` (treats user as paid)
+   - Trial prompts are suppressed
+   - Sync guide dialogs are prevented
+
+## Configuration
+
+The flag is defined in the TypeScript configuration interface (`app/src/types/config.d.ts`):
+
+```typescript
+export interface ISystem {
+    // ... other properties
+    /**
+     * Whether to hide cloud/account UI elements (for development builds)
+     */
+    hideCloudUI: boolean;
+}
+```
+
+## Backend Integration
+
+To enable this feature, the backend needs to:
+
+1. Add `hideCloudUI` field to the system configuration structure
+2. Default the value to `true` for development builds and `false` for production
+3. Expose this setting through the configuration API
+
+## Development Usage
+
+For development builds, this flag should be set to `true` by default to hide all cloud-related UI elements, making the application suitable for self-hosted or offline usage without any references to SiYuan Cloud services.
+
+## Files Modified
+
+- `app/src/types/config.d.ts` - Added hideCloudUI type definition
+- `app/src/config/index.ts` - Hide account/cloud sections in settings
+- `app/src/mobile/menu/index.ts` - Hide account/sync menu items
+- `app/src/mobile/settings/account.ts` - Protected menuAccount references
+- `app/src/layout/topBar.ts` - Hide sync button and VIP toolbar
+- `app/src/config/account.ts` - Respect hideCloudUI in onSetaccount
+- `app/src/util/needSubscribe.ts` - Bypass subscription checks
+- `app/src/sync/syncGuide.ts` - Prevent sync guide when cloud UI hidden

--- a/app/src/config/account.ts
+++ b/app/src/config/account.ts
@@ -477,7 +477,7 @@ ${renewHTML}<div class="fn__hr--b"></div>`;
         if (repos.element) {
             repos.element.innerHTML = "";
         }
-        if (window.siyuan.config.system.container === "ios") {
+        if (window.siyuan.config.system.container === "ios" || window.siyuan.config.system.hideCloudUI) {
             return;
         }
         let html = "";

--- a/app/src/config/index.ts
+++ b/app/src/config/index.ts
@@ -126,8 +126,8 @@ export const openSetting = (app: App) => {
     <li data-name="bazaar" class="b3-list-item${isHuawei() || isInHarmony() ? " fn__none" : ""}"><svg class="b3-list-item__graphic"><use xlink:href="#iconBazaar"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.bazaar}</span></li>
     <li data-name="search" class="b3-list-item"><svg class="b3-list-item__graphic"><use xlink:href="#iconSearch"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.search}</span></li>
     <li data-name="keymap" class="b3-list-item"><svg class="b3-list-item__graphic"><use xlink:href="#iconKeymap"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.keymap}</span></li>
-    <li data-name="account" class="b3-list-item"><svg class="b3-list-item__graphic"><use xlink:href="#iconAccount"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.account}</span></li>
-    <li data-name="repos" class="b3-list-item"><svg class="b3-list-item__graphic"><use xlink:href="#iconCloud"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.cloud}</span></li>
+    <li data-name="account" class="b3-list-item${window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}"><svg class="b3-list-item__graphic"><use xlink:href="#iconAccount"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.account}</span></li>
+    <li data-name="repos" class="b3-list-item${window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}"><svg class="b3-list-item__graphic"><use xlink:href="#iconCloud"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.cloud}</span></li>
     <li data-name="publish" class="b3-list-item"><svg class="b3-list-item__graphic"><use xlink:href="#iconLanguage"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.publish}</span></li>
     <li data-name="about" class="b3-list-item"><svg class="b3-list-item__graphic"><use xlink:href="#iconInfo"></use></svg><span class="b3-list-item__text">${window.siyuan.languages.about}</span></li>
   </ul>
@@ -143,8 +143,8 @@ export const openSetting = (app: App) => {
       <div class="config__tab-container config__tab-container--top fn__none" data-name="bazaar"></div>
       <div class="config__tab-container fn__none" data-name="search"></div>
       <div class="config__tab-container fn__none" style="overflow: scroll" data-name="keymap"></div>
-      <div class="config__tab-container config__tab-container--full fn__none" data-name="account"></div>
-      <div class="config__tab-container fn__none" data-name="repos"></div>
+      <div class="config__tab-container config__tab-container--full fn__none${window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}" data-name="account"></div>
+      <div class="config__tab-container fn__none${window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}" data-name="repos"></div>
       <div class="config__tab-container fn__none" data-name="publish"></div>
       <div class="config__tab-container fn__none" data-name="about"></div>
       <div class="fn__hr--b"></div>

--- a/app/src/layout/topBar.ts
+++ b/app/src/layout/topBar.ts
@@ -28,7 +28,7 @@ export const initBar = (app: App) => {
     <span class="toolbar__text">${getWorkspaceName()}</span>
     <svg class="toolbar__svg"><use xlink:href="#iconDown"></use></svg>
 </div>
-<div id="barSync" class="ariaLabel toolbar__item${window.siyuan.config.readonly ? " fn__none" : ""}">
+<div id="barSync" class="ariaLabel toolbar__item${window.siyuan.config.readonly || window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}">
     <svg><use xlink:href="#iconCloudSucc"></use></svg>
 </div>
 <button id="barBack" class="ariaLabel toolbar__item toolbar__item--disabled" aria-label="${window.siyuan.languages.goBack} ${updateHotkeyTip(window.siyuan.config.keymap.general.goBack.custom)}">
@@ -38,7 +38,7 @@ export const initBar = (app: App) => {
     <svg><use xlink:href="#iconForward"></use></svg>
 </button>
 <div class="fn__flex-1 fn__ellipsis" id="drag"><span class="fn__none">开发版，使用前请进行备份 Development version, please backup before use</span></div>
-<div id="toolbarVIP" class="fn__flex${window.siyuan.config.readonly ? " fn__none" : ""}"></div>
+<div id="toolbarVIP" class="fn__flex${window.siyuan.config.readonly || window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}"></div>
 <div id="barPlugins" class="toolbar__item ariaLabel" aria-label="${window.siyuan.languages.plugin}">
     <svg><use xlink:href="#iconPlugin"></use></svg>
 </div>
@@ -165,7 +165,7 @@ export const initBar = (app: App) => {
                 event.stopPropagation();
                 break;
             } else if (targetId === "toolbarVIP") {
-                if (!window.siyuan.config.readonly) {
+                if (!window.siyuan.config.readonly && !window.siyuan.config.system.hideCloudUI) {
                     const dialogSetting = openSetting(app);
                     dialogSetting.element.querySelector('.b3-tab-bar [data-name="account"]').dispatchEvent(new CustomEvent("click"));
                 }

--- a/app/src/mobile/menu/index.ts
+++ b/app/src/mobile/menu/index.ts
@@ -39,15 +39,17 @@ export const popMenu = () => {
 export const initRightMenu = (app: App) => {
     const menuElement = document.getElementById("menu");
     let accountHTML = "";
-    if (window.siyuan.user && !window.siyuan.config.readonly) {
-        accountHTML = `<div class="b3-menu__item" id="menuAccount">
-    <img class="b3-menu__icon" src="${window.siyuan.user.userAvatarURL}"/>
-    <span class="b3-menu__label">${window.siyuan.user.userName}</span>
-</div>`;
-    } else if (!window.siyuan.config.readonly) {
-        accountHTML = `<div class="b3-menu__item" id="menuAccount">
-    <svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>
-</div>`;
+    if (!window.siyuan.config.system.hideCloudUI) {
+        if (window.siyuan.user && !window.siyuan.config.readonly) {
+            accountHTML = `<div class="b3-menu__item" id="menuAccount">
+        <img class="b3-menu__icon" src="${window.siyuan.user.userAvatarURL}"/>
+        <span class="b3-menu__label">${window.siyuan.user.userName}</span>
+    </div>`;
+        } else if (!window.siyuan.config.readonly) {
+            accountHTML = `<div class="b3-menu__item" id="menuAccount">
+        <svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>
+    </div>`;
+        }
     }
 
     let aiHTML = `<div class="b3-menu__item${window.siyuan.config.readonly ? " fn__none" : ""}" id="menuAI">
@@ -74,7 +76,7 @@ export const initRightMenu = (app: App) => {
     <div id="menuCommand" class="b3-menu__item">
         <svg class="b3-menu__icon"><use xlink:href="#iconTerminal"></use></svg><span class="b3-menu__label">${window.siyuan.languages.commandPanel}</span>
     </div>
-    <div class="b3-menu__item${window.siyuan.config.readonly ? " fn__none" : ""}" id="menuSyncNow">
+    <div class="b3-menu__item${window.siyuan.config.readonly || window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}" id="menuSyncNow">
         <svg class="b3-menu__icon"><use xlink:href="#iconCloudSucc"></use></svg><span class="b3-menu__label">${window.siyuan.languages.syncNow}</span>
     </div>
     <div class="b3-menu__item${window.siyuan.config.readonly ? " fn__none" : ""}" id="menuNewDoc">
@@ -117,7 +119,7 @@ export const initRightMenu = (app: App) => {
     <div class="b3-menu__item${window.siyuan.config.readonly ? " fn__none" : ""}" id="menuAppearance">
         <svg class="b3-menu__icon"><use xlink:href="#iconTheme"></use></svg><span class="b3-menu__label">${window.siyuan.languages.appearance}</span>
     </div>
-    <div id="menuSync" class="b3-menu__item${window.siyuan.config.readonly ? " fn__none" : ""}">
+    <div id="menuSync" class="b3-menu__item${window.siyuan.config.readonly || window.siyuan.config.system.hideCloudUI ? " fn__none" : ""}">
         <svg class="b3-menu__icon"><use xlink:href="#iconCloud"></use></svg><span class="b3-menu__label">${window.siyuan.languages.cloud}</span>
     </div>
     <div class="b3-menu__item" id="menuAbout">
@@ -269,7 +271,7 @@ export const initRightMenu = (app: App) => {
                 event.preventDefault();
                 event.stopPropagation();
                 break;
-            } else if (target.id === "menuAccount") {
+            } else if (target.id === "menuAccount" && !window.siyuan.config.system.hideCloudUI) {
                 event.preventDefault();
                 event.stopPropagation();
                 if (document.querySelector("#menuAccount img")) {

--- a/app/src/mobile/settings/account.ts
+++ b/app/src/mobile/settings/account.ts
@@ -145,7 +145,10 @@ ${renewHTML}<div class="fn__hr--b"></div>`;
                         fetchPost("/api/setting/logoutCloudUser", {}, () => {
                             window.siyuan.user = null;
                             closePanel();
-                            document.getElementById("menuAccount").innerHTML = `<svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>`;
+                            const menuAccountElement = document.getElementById("menuAccount");
+                            if (menuAccountElement) {
+                                menuAccountElement.innerHTML = `<svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>`;
+                            }
                             processSync();
                         });
                         event.preventDefault();
@@ -184,10 +187,12 @@ ${renewHTML}<div class="fn__hr--b"></div>`;
                             showMessage(window.siyuan.languages.refreshUser, 3000);
                             showAccountInfo();
                             const menuAccountElement = document.getElementById("menuAccount");
-                            if (window.siyuan.user) {
-                                menuAccountElement.innerHTML = `<img class="b3-menu__icon" src="${window.siyuan.user.userAvatarURL}"/><span class="b3-menu__label">${window.siyuan.user.userName}</span>`;
-                            } else {
-                                menuAccountElement.innerHTML = `<svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>`;
+                            if (menuAccountElement) {
+                                if (window.siyuan.user) {
+                                    menuAccountElement.innerHTML = `<img class="b3-menu__icon" src="${window.siyuan.user.userAvatarURL}"/><span class="b3-menu__label">${window.siyuan.user.userName}</span>`;
+                                } else {
+                                    menuAccountElement.innerHTML = `<svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>`;
+                                }
                             }
                             processSync();
                         });
@@ -268,12 +273,15 @@ const afterLogin = (response: IWebSocketData, deactive = false) => {
     if (deactive) {
         hideElements(["dialog"]);
         confirmDialog("⚠️ " + window.siyuan.languages.deactivateUser, window.siyuan.languages.deactivateUserTip, () => {
-            fetchPost("/api/account/deactivate", {}, () => {
-                window.siyuan.user = null;
-                closePanel();
-                document.getElementById("menuAccount").innerHTML = `<svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>`;
-                processSync();
-            });
+                                        fetchPost("/api/account/deactivate", {}, () => {
+                                window.siyuan.user = null;
+                                closePanel();
+                                const menuAccountElement = document.getElementById("menuAccount");
+                                if (menuAccountElement) {
+                                    menuAccountElement.innerHTML = `<svg class="b3-menu__icon"><use xlink:href="#iconAccount"></use></svg><span class="b3-menu__label">${window.siyuan.languages.login}</span>`;
+                                }
+                                processSync();
+                            });
         });
     } else {
         fetchPost("/api/setting/getCloudUser", {
@@ -281,8 +289,11 @@ const afterLogin = (response: IWebSocketData, deactive = false) => {
         }, response => {
             window.siyuan.user = response.data;
             closePanel();
-            document.getElementById("menuAccount").innerHTML = `<img class="b3-menu__icon" src="${window.siyuan.user.userAvatarURL}"/>
+            const menuAccountElement = document.getElementById("menuAccount");
+            if (menuAccountElement) {
+                menuAccountElement.innerHTML = `<img class="b3-menu__icon" src="${window.siyuan.user.userAvatarURL}"/>
 <span class="b3-menu__label">${window.siyuan.user.userName}</span>`;
+            }
             processSync();
         });
     }

--- a/app/src/sync/syncGuide.ts
+++ b/app/src/sync/syncGuide.ts
@@ -145,7 +145,7 @@ export const getSyncCloudList = (cloudPanelElement: Element, reload = false, cb?
 };
 
 export const syncGuide = (app?: App) => {
-    if (window.siyuan.config.readonly) {
+    if (window.siyuan.config.readonly || window.siyuan.config.system.hideCloudUI) {
         return;
     }
     /// #if MOBILE

--- a/app/src/types/config.d.ts
+++ b/app/src/types/config.d.ts
@@ -1576,6 +1576,10 @@ declare namespace Config {
          * Disabled features.
          */
         disabledFeatures: string[];
+        /**
+         * Whether to hide cloud/account UI elements (for development builds)
+         */
+        hideCloudUI: boolean;
     }
 
     /**

--- a/app/src/util/needSubscribe.ts
+++ b/app/src/util/needSubscribe.ts
@@ -2,6 +2,11 @@ import {showMessage} from "../dialog/message";
 import {getCloudURL} from "../config/util/about";
 
 export const needSubscribe = (tip = window.siyuan.languages._kernel[29]) => {
+    // If cloud UI is hidden, bypass subscription checks
+    if (window.siyuan.config.system.hideCloudUI) {
+        return false;
+    }
+    
     if (window.siyuan.user && (window.siyuan.user.userSiYuanProExpireTime === -1 || window.siyuan.user.userSiYuanProExpireTime > 0)) {
         return false;
     }
@@ -19,5 +24,9 @@ export const needSubscribe = (tip = window.siyuan.languages._kernel[29]) => {
 };
 
 export const isPaidUser = () => {
+    // If cloud UI is hidden, treat as paid user
+    if (window.siyuan.config.system.hideCloudUI) {
+        return true;
+    }
     return window.siyuan.user && (0 === window.siyuan.user.userSiYuanSubscriptionStatus || 1 === window.siyuan.user.userSiYuanOneTimePayStatus);
 };


### PR DESCRIPTION
## Feature or bug? 特性或者缺陷？
Feature: Cloud UI Removal

## Multilingual or copywriting? 多语言或者文案？
Not applicable. This is a feature implementation.

## Dev branch!

This PR implements a new feature to remove all UI elements related to SiYuan Cloud, account management, and subscriptions.

**Why this change?**
The primary goal is to offer a cleaner, cloud-free user experience, particularly beneficial for self-hosted or development environments, by suppressing all cloud-related UI, prompts, and subscription checks.

**Key Changes:**
-   **New Configuration Flag:** Introduces `hideCloudUI` in the system configuration (`window.siyuan.config.system.hideCloudUI`).
-   **UI Hiding:**
    -   Hides "Account" and "Cloud/Repos" sections in both desktop and mobile settings.
    -   Removes "Sync", "Login", and "Upgrade" buttons/menu items from the topbar and mobile menu.
-   **Subscription & Sync Bypass:**
    -   Bypasses `needSubscribe()` and `isPaidUser()` checks, treating the user as paid when `hideCloudUI` is true.
    -   Prevents the `syncGuide()` dialog from appearing.

**Backend Integration Required:**
For full functionality, the `hideCloudUI` field needs to be added to the Go backend's system configuration, with a default value of `true` for development builds and `false` for production.

---
<a href="https://cursor.com/background-agent?bcId=bc-02180f73-f22d-43e7-9934-26a5d3f33e43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02180f73-f22d-43e7-9934-26a5d3f33e43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>